### PR TITLE
Make rundeck user/group system user/group

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,6 +28,7 @@ class rundeck::install {
     group { $group:
       ensure => present,
       gid    => $group_id,
+      system => true,
     }
 
     if $group != 'rundeck' {
@@ -43,6 +44,7 @@ class rundeck::install {
       groups => [$group],
       uid    => $user_id,
       gid    => $group_id,
+      system => true,
       before => File['/var/rundeck'],
     }
 


### PR DESCRIPTION
#### Pull Request (PR) description
The default rundeck user and group should probably be declared as system.

#### This Pull Request (PR) fixes the following issues
Fixes #380
